### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
       - lint
       - build
       - test
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/shm11C3/md-xformer/security/code-scanning/1](https://github.com/shm11C3/md-xformer/security/code-scanning/1)

In general, to fix this class of issue you must explicitly declare a `permissions` block either at the workflow root or for each job, so that the `GITHUB_TOKEN` is restricted to only the scopes required. This prevents the workflow from silently inheriting broader, potentially write-level defaults from the repository or organization.

For this specific workflow, all existing jobs except `merge-gate` already define limited permissions. The safest and least-disruptive fix is to add a `permissions` block to the `merge-gate` job itself. Since `merge-gate` only checks previous job results and runs a local Node script, it does not appear to need any write access. It may only need read access to `contents` (which is CodeQL’s suggested minimal starting point) or possibly no permissions, but granting `contents: read` is a conservative and compatible choice. Therefore, inside `.github/workflows/ci.yml`, under the `merge-gate` job definition (line 99 onward), add:

```yaml
    permissions:
      contents: read
```

This keeps existing functionality intact while satisfying CodeQL’s requirement and aligning with least-privilege principles. No imports or additional methods are needed, since this is only a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
